### PR TITLE
Use Pulse protocol instead of Juniper with Openconnect

### DIFF
--- a/bin/ucsf-vpn
+++ b/bin/ucsf-vpn
@@ -1091,7 +1091,7 @@ function openconnect_start() {
 
     ## openconnect options
     opts="$extras"
-    opts="$opts --juniper ${url}"
+    opts="$opts --protocol=pulse ${url}"
     opts="$opts --background"
 
     if [[ -n $user ]]; then


### PR DESCRIPTION
With OpenConnect version v8.10, I get kicked of the UCSF VPN after ~10 minutes when using the Juniper compatible protocol (via the --juniper flag). 

Given that the UCSF VPN only officially supports Pulse, I changed the protocol used by OpenConnect to Pulse compatible (--protocol=pulse). 

I'm not sure if this breaks earlier versions of OpenConnect where that option is not available.