### PR TITLE
Lookup credentials based on user before su

### DIFF
--- a/bin/ucsf-vpn
+++ b/bin/ucsf-vpn
@@ -1362,7 +1362,9 @@ validate=
 dryrun=false
 realm=
 extras=${UCSF_VPN_EXTRAS}
-protocol=${UCSF_VPN_PROTOCOL:-nc}
+# RB changes
+#protocol=${UCSF_VPN_PROTOCOL:-nc}
+protocol=${UCSF_VPN_PROTOCOL:-pulse}
 gui=true
 notification=false
 speed=1.0

--- a/bin/ucsf-vpn
+++ b/bin/ucsf-vpn
@@ -128,6 +128,10 @@
 ### * UCSF Managing Your Passwords:
 ###   - https://it.ucsf.edu/services/managing-your-passwords
 ###
+### Version 5.4.1
+### Try harder to get .netrc from original user.
+### Ross Boylan (ross.boylan@ucsf.edu)
+
 ### Version: 5.4.0
 ### Copyright: Henrik Bengtsson (2016-2022)
 ### License: GPL (>= 2.1) [https://www.gnu.org/licenses/gpl.html]
@@ -435,9 +439,12 @@ function status() {
 # Credentials, e.g. .netrc, prompting for password, etc.
 # -------------------------------------------------------------------------
 function source_netrc() {
-    local rcfile pattern found bfr
+    local rcfile pattern found bfr defaultrc
 
-    rcfile=${NETRC:-~/.netrc}
+    # eval is another solution, but a security risk
+    # https://stackoverflow.com/questions/7358611/get-users-home-directory-when-they-run-a-script-as-root
+    defaultrc=$(getent passwd $(logname) | cut -d: -f6)/.netrc
+    rcfile=${NETRC:-${defaultrc}}
     ## No such file?
     if [[ ! -f "${rcfile}" ]]; then
         mdebug "No .netrc file: $rcfile"

--- a/bin/ucsf-vpn
+++ b/bin/ucsf-vpn
@@ -464,7 +464,7 @@ function source_netrc() {
 
     # eval is another solution, but a security risk
     # https://stackoverflow.com/questions/7358611/get-users-home-directory-when-they-run-a-script-as-root
-    defaultrc=$(getent passwd $(logname) | cut -d: -f6)/.netrc
+    defaultrc=$(getent passwd "$(logname)" | cut -d: -f6)/.netrc
     rcfile=${NETRC:-${defaultrc}}
     ## No such file?
     if [[ ! -f "${rcfile}" ]]; then


### PR DESCRIPTION
When running as root after su/sudo the current code looks for credentials in /root/.netrc.  With this patch, it looks in the original user's home directory instead.  The behavior is probably *nix specific, but I think the original was too.

Hmm, this branch also includes an unrelated change to the default protocol, which might or might not be a good idea but is a completely separate issue.  It does work with sufficiently recent versions of openconnect; they must be newer than the version currently in Debian stable.